### PR TITLE
Add spec tests

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,5 +1,12 @@
 fixtures:
   repositories:
-    stdlib: "https://github.com/puppetlabs/puppetlabs-stdlib.git"
+    concat:
+      repo: "git://github.com/puppetlabs/puppetlabs-concat.git"
+    haproxy:
+      repo: 'git://github.com/puppetlabs/puppetlabs-haproxy.git'
+      ref: '1.5.0'
+    stdlib:
+      repo: 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
+      ref: '4.11.0'
   symlinks:
     haproxywrapper: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,31 @@
-.*.sw?
-/pkg
-/spec/fixtures
-/.rspec_system
-/.vagrant
-/.bundle
-/vendor
-/Gemfile.lock
-/junit
-/log
-.yardoc
+# Default .gitignore for Ruby
+*.gem
+*.rbc
+.bundle
+.config
 coverage
+InstalledFiles
+lib/bundler/man
+pkg
+rdoc
+spec/reports
+test/tmp
+test/version_tmp
+tmp
+
+# YARD artifacts
+.yardoc
+_yardoc
+doc/
+
+# Vim
+*.swp
+
+# OS X
+.DS_Store
+
+# Puppet
+coverage/
+spec/fixtures/modules/*
+spec/fixtures/manifests/*
+Gemfile.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,38 +1,90 @@
 ---
 language: ruby
-bundler_args: --without development system_tests
-before_install: rm Gemfile.lock || true
+
 rvm:
   - 1.8.7
   - 1.9.3
   - 2.0.0
   - 2.1.0
-script: bundle exec rake test
+  - 2.3.1
+
 env:
-  - PUPPET_GEM_VERSION="~> 2.7.0"
-  - PUPPET_GEM_VERSION="~> 3.2.0"
-  - PUPPET_GEM_VERSION="~> 3.3.0"
-  - PUPPET_GEM_VERSION="~> 3.4.0"
-  - PUPPET_GEM_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_GEM_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.1.0"
+    - PUPPET_GEM_VERSION="~> 3.2.0"
+    - PUPPET_GEM_VERSION="~> 3.3.0"
+    - PUPPET_GEM_VERSION="~> 3.4.0"
+    - PUPPET_GEM_VERSION="~> 3.5.0"
+    - PUPPET_GEM_VERSION="~> 3.6.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.8.0"
+    - PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"
+    - PUPPET_GEM_VERSION="~> 4.1.0"
+    - PUPPET_GEM_VERSION="~> 4.2.0"
+    - PUPPET_GEM_VERSION="~> 4.3.0"
+    - PUPPET_GEM_VERSION="~> 4.4.0"
+    - PUPPET_GEM_VERSION="~> 4.5.0"
+    - PUPPET_GEM_VERSION="~> 4.6.0"
+    - PUPPET_GEM_VERSION="~> 4.7.0"
+    - PUPPET_GEM_VERSION="~> 4.8.0"
+    - PUPPET_GEM_VERSION="~> 4"
+
+sudo: false
+
+script: 'bundle exec rake validate && bundle exec rake lint && SPEC_OPTS="--format documentation" bundle exec rake spec'
+
 matrix:
+  fast_finish: true
   exclude:
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 2.7.0"
-    
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 2.7.0"
-    
-  # Ruby 2.1.0
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.0.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.1.0
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.0.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.1.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.2.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.3.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.4.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.5.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.6.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.7.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4.8.0"
+    - rvm: 1.8.7
+      env: PUPPET_GEM_VERSION="~> 4"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.1.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.2.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.3.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.4.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.5.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.6.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.7.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3.8.0"
+    - rvm: 2.3.1
+      env: PUPPET_GEM_VERSION="~> 3" FUTURE_PARSER="yes"
+
+notifications:
+  email: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,34 +1,31 @@
-source "https://rubygems.org"
+source ENV['GEM_SOURCE'] || 'https://rubygems.org'
 
-group :test do
-  gem "rake"
-  gem "puppet", ENV['PUPPET_GEM_VERSION'] || '~> 3.8.0'
-  gem "rspec", '< 3.2.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
-  gem "puppetlabs_spec_helper"
-  gem "metadata-json-lint"
-  gem "rspec-puppet-facts"
-  gem 'rubocop', '0.33.0'
-  gem 'simplecov', '>= 0.11.0'
-  gem 'simplecov-console'
-
-  gem "puppet-lint-absolute_classname-check"
-  gem "puppet-lint-leading_zero-check"
-  gem "puppet-lint-trailing_comma-check"
-  gem "puppet-lint-version_comparison-check"
-  gem "puppet-lint-classes_and_types_beginning_with_digits-check"
-  gem "puppet-lint-unquoted_string-check"
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+  gem 'puppet', puppetversion, :require => false
+else
+  gem 'puppet', :require => false
 end
 
-group :development do
-  gem "travis"
-  gem "travis-lint"
-  gem "puppet-blacksmith"
-  gem "guard-rake"
-end
+gem 'puppetlabs_spec_helper', '>= 1.2.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec-puppet'
+gem 'puppet-lint', '~> 2.0'
+gem 'puppet-lint-absolute_classname-check'
+gem 'puppet-lint-alias-check'
+gem 'puppet-lint-empty_string-check'
+gem 'puppet-lint-file_ensure-check'
+gem 'puppet-lint-file_source_rights-check'
+gem 'puppet-lint-leading_zero-check'
+gem 'puppet-lint-spaceship_operator_without_tag-check'
+gem 'puppet-lint-trailing_comma-check'
+gem 'puppet-lint-undef_in_function-check'
+gem 'puppet-lint-unquoted_string-check'
+gem 'puppet-lint-variable_contains_upcase'
 
-group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
-  gem "beaker-puppet_install_helper"
-end
+gem 'rspec',              '~> 2.0'   if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'rake',               '~> 10.0'  if RUBY_VERSION >= '1.8.7' && RUBY_VERSION < '1.9'
+gem 'json',               '<= 1.8'   if RUBY_VERSION < '2.0.0'
+gem 'json_pure',          '<= 2.0.1' if RUBY_VERSION < '2.0.0'
+gem 'metadata-json-lint', '0.0.11'   if RUBY_VERSION < '1.9'
+gem 'metadata-json-lint'             if RUBY_VERSION >= '1.9'
+gem 'rubocop'                        if RUBY_VERSION >= '2.0.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,63 +1,20 @@
-require 'rubygems'
-require 'bundler/setup'
-
 require 'puppetlabs_spec_helper/rake_tasks'
-require 'puppet/version'
-require 'puppet/vendor/semantic/lib/semantic' unless Puppet.version.to_f < 3.6
 require 'puppet-lint/tasks/puppet-lint'
-require 'puppet-syntax/tasks/puppet-syntax'
-require 'metadata-json-lint/rake_task'
-require 'rubocop/rake_task'
 
-# These gems aren't always present, for instance
-# on Travis with --without development
-begin
-  require 'puppet_blacksmith/rake_tasks'
-rescue LoadError # rubocop:disable Lint/HandleExceptions
-end
-
-RuboCop::RakeTask.new
-
-exclude_paths = [
-  "bundle/**/*",
-  "pkg/**/*",
-  "vendor/**/*",
-  "spec/**/*",
-]
-
-# Coverage from puppetlabs-spec-helper requires rcov which
-# doesn't work in anything since 1.8.7
-Rake::Task[:coverage].clear
-
-Rake::Task[:lint].clear
-
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.send('disable_140chars')
 PuppetLint.configuration.relative = true
-PuppetLint.configuration.disable_80chars
-PuppetLint.configuration.disable_class_inherits_from_params_class
-PuppetLint.configuration.disable_class_parameter_defaults
-PuppetLint.configuration.fail_on_warnings = true
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
 
-PuppetLint::RakeTask.new :lint do |config|
-  config.ignore_paths = exclude_paths
+desc 'Validate manifests, templates, and ruby files'
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
 end
-
-PuppetSyntax.exclude_paths = exclude_paths
-
-desc "Run acceptance tests"
-RSpec::Core::RakeTask.new(:acceptance) do |t|
-  t.pattern = 'spec/acceptance'
-end
-
-desc "Populate CONTRIBUTORS file"
-task :contributors do
-  system("git log --format='%aN' | sort -u > CONTRIBUTORS")
-end
-
-desc "Run syntax, lint, and spec tests."
-task :test => [
-  :metadata_lint,
-  :syntax,
-  :lint,
-  :rubocop,
-  :spec,
-]

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,7 +12,7 @@
 #
 class haproxywrapper (
   $custom_fragment  = undef,
-  $defaults_options  = undef,
+  $default_options  = undef,
   $global_options   = undef,
   $merge_options    = undef,
   $package_ensure   = undef,
@@ -50,7 +50,7 @@ class haproxywrapper (
     validate_bool($merge_options)
   }
   if $package_ensure != undef {
-    validate_re($package_ensure, '^(present|absent)$')
+    validate_re($package_ensure, '^(present|installed|absent)$', 'haproxywrapper::package_ensure must be absent, present or installed')
   }
   if $package_name != undef {
     validate_string($package_name)
@@ -59,67 +59,67 @@ class haproxywrapper (
     validate_string($restart_command)
   }
   if $service_ensure != undef {
-    validate_re($service_ensure, '^(running|stopped)$')
+    validate_re($service_ensure, '^(running|stopped)$', 'haproxywrapper::service_ensure must be running or stopped')
   }
   if $service_options != undef {
     validate_string($service_options)
   }
   if $config_dir != undef {
     if is_absolute_path($config_dir) == false {
-      error("${config_dir} is not an absolute path.")
+      fail("${config_dir} is not an absolute path.")
     }
   }
   if $config_file != undef {
     validate_string($config_file)
   }
-  class { 'haproxy':
-    custom_fragment => $custom_fragment,
+  class { '::haproxy':
+    custom_fragment  => $custom_fragment,
     defaults_options => pick($default_options, $::haproxy::params::defaults_options),
-    global_options  => pick($global_options, $::haproxy::params::global_options),
-    merge_options   => pick($merge_options, $::haproxy::params::merge_options),
-    package_ensure  => pick($package_ensure, 'present'),
-    package_name    => pick($package_name, $::haproxy::params::package_name),
-    restart_command => $restart_command,
-    service_ensure  => pick($service_ensure, 'running'),
-    service_manage  => pick($service_manage, true),
-    config_dir      => pick($config_dir, $::haproxy::params::config_dir),
-    config_file     => pick($config_file, $::haproxy::params::config_file),
+    global_options   => pick($global_options, $::haproxy::params::global_options),
+    merge_options    => pick($merge_options, $::haproxy::params::merge_options),
+    package_ensure   => pick($package_ensure, 'present'),
+    package_name     => pick($package_name, $::haproxy::params::package_name),
+    restart_command  => $restart_command,
+    service_ensure   => pick($service_ensure, 'running'),
+    service_manage   => pick($service_manage, true),
+    config_dir       => pick($config_dir, $::haproxy::params::config_dir),
+    config_file      => pick($config_file, $::haproxy::params::config_file),
   }
 
   if $listen != undef {
-    create_resources('::haproxy::listen', $listen)
+    create_resources('haproxy::listen', $listen)
   }
   if $frontend != undef {
-    create_resources('::haproxy::frontend', $frontend)
+    create_resources('haproxy::frontend', $frontend)
   }
   if $backend != undef {
-    create_resources('::haproxy::backend', $backend)
+    create_resources('haproxy::backend', $backend)
   }
   if $balancermember != undef {
-    create_resources('::haproxy::balancermember', $balancermember)
+    create_resources('haproxy::balancermember', $balancermember)
   }
   if $userlist != undef {
-    create_resources('::haproxy::userlist', $userlist)
+    create_resources('haproxy::userlist', $userlist)
   }
   if $peers != undef {
-    create_resources('::haproxy::peers', $peers)
+    create_resources('haproxy::peers', $peers)
   }
   if $peer != undef {
-    create_resources('::haproxy::peer', $peer)
+    create_resources('haproxy::peer', $peer)
   }
   if $mailers != undef {
-    create_resources('::haproxy::mailers', $mailers)
+    create_resources('haproxy::mailers', $mailers)
   }
   if $mailer != undef {
-    create_resources('::haproxy::mailer', $mailer)
+    create_resources('haproxy::mailer', $mailer)
   }
   if $instance != undef {
-    create_resources('::haproxy::instance', $instance)
+    create_resources('haproxy::instance', $instance)
   }
   if $instance_service != undef {
-    create_resources('::haproxy::instance_service', $instance_service)
+    create_resources('haproxy::instance_service', $instance_service)
   }
   if $mapfile != undef {
-    create_resources('::haproxy::mapfile', $mapfile)
+    create_resources('haproxy::mapfile', $mapfile)
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -1,9 +1,9 @@
 {
-  "name": "puppet-module-haproxywrapper",
+  "name": "propyless-haproxywrapper",
   "version": "0.1.0",
   "author": "Takeshi Larsson",
   "summary": "Allows usage of puppetlabs-haproxy in hiera",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "source": "https://github.com/propyless/puppet-module-haproxywrapper",
   "project_page": "https://github.com/propyless/puppet-module-haproxywrapper",
   "issues_url": "https://github.com/propyless/puppet-module-haproxywrapper/issues",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,151 @@
+require 'spec_helper'
+describe 'haproxywrapper' do
+  mandatory_params = {}
+  let(:facts) { mandatory_global_facts }
+  let(:params) { mandatory_params }
+
+  describe 'with defaults for all parameters' do
+    it { should compile.with_all_deps }
+    it { should contain_class('haproxywrapper') }
+    it { should contain_class('haproxy::params') }
+    it do
+      should contain_class('haproxy').with({
+        'custom_fragment'  => nil, # /!\ no default provided
+        'defaults_options' => { 'log' => 'global', 'stats' => 'enable', 'option' => [ 'redispatch' ], 'retries' => '3', 'timeout' => [ 'http-request 10s', 'queue 1m', 'connect 10s', 'client 1m', 'server 1m', 'check 10s' ], 'maxconn' => '8000' },
+        'global_options'   => { 'log' => '127.0.0.1 local0', 'chroot' => '/var/lib/haproxy', 'pidfile' => '/var/run/haproxy.pid', 'maxconn' => '4000', 'user' => 'haproxy', 'group' => 'haproxy', 'daemon' => '', 'stats' => 'socket /var/lib/haproxy/stats' },
+        'merge_options'    => false,
+        'package_ensure'   => 'present',
+        'package_name'     => 'haproxy',
+        'restart_command'  => nil, # /!\ no default provided
+        'service_ensure'   => 'running',
+        'service_manage'   => true,
+        'config_dir'       => '/etc/haproxy',
+        'config_file'      => '/etc/haproxy/haproxy.cfg',
+      })
+    end
+
+    it { should have_haproxy__listen_resource_count(0) }
+    it { should have_haproxy__frontend_resource_count(0) }
+    it { should have_haproxy__backend_resource_count(0) }
+    it { should have_haproxy__balancermember_resource_count(0) }
+    it { should have_haproxy__userlist_resource_count(0) }
+    it { should have_haproxy__peers_resource_count(0) }
+    it { should have_haproxy__peer_resource_count(0) }
+    it { should have_haproxy__mailers_resource_count(0) }
+    it { should have_haproxy__mailer_resource_count(0) }
+    it { should have_haproxy__instance_resource_count(1) } # one from haproxy, but none from haproxywrapper
+    it { should have_haproxy__instance_service_resource_count(0) }
+    it { should have_haproxy__mapfile_resource_count(0) }
+  end
+
+  describe 'with balancermember set to valid hash (containing two keys)' do
+    let(:params) do
+      mandatory_params.merge({
+        :balancermember => {
+          'puppet1' => {
+            'listening_service' => 'puppetmasters',
+            'ports'             => '8140',
+            'server_names'      => 'puppet1',
+            'ipaddresses'       => '127.0.1.1',
+            'options'           => 'check port 8990'
+          },
+          'puppet2' => {
+            'listening_service' => 'puppetmasters',
+            'ports'             => '8140',
+            'server_names'      => 'puppet2',
+            'ipaddresses'       => '127.0.1.2',
+            'options'           => 'check port 8990'
+          },
+        }
+      })
+    end
+
+    it do
+      should contain_haproxy__balancermember('puppet1').with({
+        'listening_service' => 'puppetmasters',
+        'ports'             => '8140',
+        'server_names'      => 'puppet1',
+        'ipaddresses'       => '127.0.1.1',
+        'options'           => 'check port 8990'
+      })
+    end
+    it do
+      should contain_haproxy__balancermember('puppet2').with({
+        'listening_service' => 'puppetmasters',
+        'ports'             => '8140',
+        'server_names'      => 'puppet2',
+        'ipaddresses'       => '127.0.1.2',
+        'options'           => 'check port 8990'
+      })
+    end
+    it { should have_haproxy__balancermember_resource_count(2) }
+  end
+
+  describe 'variable type and content validations' do
+    validations = {
+      'absolute_path' => {
+        :name    => %w(config_dir), # /!\ config_file should also be tested with validate_absolute_path()
+        :valid   => %w(/absolute/filepath /absolute/directory/),
+        :invalid => ['string', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
+        :message => 'is not an absolute path',
+      },
+      'array' => {
+        :name    => %w(),
+        :valid   => [%w(array)],
+        :invalid => ['string', { 'ha' => 'sh' }, 3, 2.42, true, false],
+        :message => 'is not an Array',
+      },
+      'boolean' => {
+        :name    => %w(merge_options),
+        :valid   => [true, false],
+        :invalid => ['true', 'false', %w(array), { 'ha' => 'sh' }, 3, 2.42, nil],
+        :message => '(is not a boolean|Unknown type of boolean given)',
+      },
+      'hash' => {
+        :name    => %w(default_options global_options),
+        :valid   => [], # valid hashes are to complex to block test them here.
+        :invalid => ['string', 3, 2.42, %w(array), true, false, nil],
+        :message => 'is not a Hash',
+      },
+      'regex_package_ensure' => {
+        :name    => %w(package_ensure),
+        :valid   => ['present', 'installed', 'absent'],
+        :invalid => ['invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
+        :message => '(must be absent, present or installed|input needs to be a String)',
+      },
+      'regex_service_ensure' => {
+        :name    => %w(service_ensure),
+        :valid   => ['running', 'stopped'],
+        :invalid => ['invalid', %w(array), { 'ha' => 'sh' }, 3, 2.42, true, false, nil],
+        :message => '(must be running or stopped|input needs to be a String)',
+      },
+      'string' => {
+        :name    => %w(custom_fragment package_name restart_command service_options),
+        :valid   => %w(string),
+        :invalid => [%w(array), { 'ha' => 'sh' }, true, false], # removed integer and float for Puppet 3 compatibility
+        :message => 'is not a string',
+      },
+    }
+
+    validations.sort.each do |type, var|
+      var[:name].each do |var_name|
+        var[:params] = {} if var[:params].nil?
+        var[:valid].each do |valid|
+          context "when #{var_name} (#{type}) is set to valid #{valid} (as #{valid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => valid, }].reduce(:merge) }
+            it { should compile }
+          end
+        end
+
+        var[:invalid].each do |invalid|
+          context "when #{var_name} (#{type}) is set to invalid #{invalid} (as #{invalid.class})" do
+            let(:params) { [mandatory_params, var[:params], { :"#{var_name}" => invalid, }].reduce(:merge) }
+            it 'should fail' do
+              expect { should contain_class(subject) }.to raise_error(Puppet::Error, /#{var[:message]}/)
+            end
+          end
+        end
+      end # var[:name].each
+    end # validations.sort.each
+  end # describe 'variable type and content validations'
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,20 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |config|
+  config.hiera_config = 'spec/fixtures/hiera/hiera.yaml'
+  config.before :each do
+    # Ensure that we don't accidentally cache facts and environment between
+    # test cases.  This requires each example group to explicitly load the
+    # facts being exercised with something like
+    # Facter.collection.loader.load(:ipaddress)
+    Facter.clear
+    Facter.clear_messages
+  end
+end
+
+def mandatory_global_facts
+  {
+    :osfamily  => 'RedHat',    # used in haproxy
+    :ipaddress => '127.0.0.1', # used in haproxy
+  }
+end


### PR DESCRIPTION
Hej @propyless hope you are doing good and well !

This commit adds the testing framework we are using for our other modules as well.
It was needed to do some minor changes in the class to get the spec tests successfully executed.

On the create_resources() calls it was needed to use relative paths because otherwise it failed with:
```
Invalid tag "::haproxy::balancermember" at /home/travis/build/Phil-Friderici/puppet-module-haproxywrapper/spec/fixtures/modules/haproxywrapper/manifests/init.pp:99 on node testing-worker-linux-docker-4d596fb5-3489-linux-10.prod.travis-ci.org
```
It felt stupid to do so but didn't worked otherwise.

If you don't have time to work on this module anymore, I can take over the mainenance for it.

Thanks & phile grüße
PS: you can find the Travis results here: https://github.com/Phil-Friderici/puppet-module-haproxywrapper/pull/1